### PR TITLE
Launcher: follow-up Linux Docker target fixes

### DIFF
--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
@@ -143,6 +143,7 @@ def load_docker_linux_spec(
             family_config.container_name_prefix,
             image_name,
             repo_root,
+            launcher_dir.resolve(),
         ),
         local_repo_root=repo_root,
         local_launcher_dir=launcher_dir.resolve(),
@@ -459,6 +460,13 @@ def _inspect_docker_value(command: list[str]) -> str:
     return result.stdout.strip()
 
 
-def _build_container_name(prefix: str, image_name: str, repo_root: Path) -> str:
-    scope_hash = hashlib.sha256(f"{image_name}|{repo_root}".encode("utf-8")).hexdigest()[:12]
+def _build_container_name(
+    prefix: str,
+    image_name: str,
+    repo_root: Path,
+    launcher_dir: Path,
+) -> str:
+    scope_hash = hashlib.sha256(
+        f"{image_name}|{repo_root}|{launcher_dir}".encode("utf-8")
+    ).hexdigest()[:12]
     return f"{prefix}-{scope_hash}"

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
@@ -100,7 +100,8 @@ def load_docker_linux_spec(
 
     config = Config(project, model, target, base_dir, dry_run=False, stub_install=False)
     runtime = dict(config.model.get("runtime") or {})
-    if (runtime.get("target_platform") or "").strip() != "linux":
+    target_platform = str(runtime.get("target_platform") or target).strip().lower()
+    if target_platform != "linux":
         return None
 
     target_variant = (runtime.get("target_variant") or "").strip().lower()

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/prepare_project_docker.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/prepare_project_docker.py
@@ -617,6 +617,7 @@ def project_cache_materialize_shell(
     launcher_cache_dir = shlex.quote(f"{launcher_dir}/{subdir}")
     return (
         f"if [[ -d {cache_dir} ]]; then "
+        f"rm -rf {launcher_cache_dir} && "
         f"mkdir -p {launcher_cache_dir} && "
         f"cp -a {cache_dir}/. {launcher_cache_dir}/; "
         "fi"

--- a/tools/robotick-launcher/tests/launcher/test_remote_linux.py
+++ b/tools/robotick-launcher/tests/launcher/test_remote_linux.py
@@ -784,6 +784,34 @@ def test_load_docker_linux_x64_spec_uses_prepared_project_image_when_present(tmp
     assert spec.image_name == "robotick-proj-linux-docker:linux-x64-deadbeef"
 
 
+def test_load_docker_linux_x64_spec_defaults_target_platform_from_target(tmp_path):
+    repo_root = tmp_path / "repo"
+    project_dir = repo_root / "robots" / "proj"
+    project_dir.mkdir(parents=True)
+    (repo_root / "robotick" / "robotick-engine").mkdir(parents=True)
+
+    (project_dir / "proj.project.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "runtime": {
+                    "engine": {
+                        "local_path": "${PROJECT_DIR}/../../robotick/robotick-engine"
+                    },
+                }
+            }
+        )
+    )
+    (project_dir / "proj-face.model.yaml").write_text(
+        yaml.safe_dump({"runtime": {"target_variant": "x86_64"}})
+    )
+
+    spec = load_docker_linux_x64_spec("proj", "proj-face", "linux", project_dir)
+
+    assert spec is not None
+    assert spec.family == "linux-x64"
+    assert spec.supports_runtime is True
+
+
 def test_build_docker_linux_x64_execs_inside_keepalive_container(monkeypatch):
     spec = _docker_linux_spec(
         family="linux-x64",

--- a/tools/robotick-launcher/tests/launcher/test_remote_linux.py
+++ b/tools/robotick-launcher/tests/launcher/test_remote_linux.py
@@ -210,6 +210,32 @@ def test_run_remote_linux_wraps_child_process_and_exports_library_path(monkeypat
     assert callable(on_interrupt)
 
 
+def test_load_docker_linux_spec_uses_model_scoped_container_name(tmp_path):
+    repo_root = tmp_path / "repo"
+    project_dir = repo_root / "robots" / "pip-e"
+    project_dir.mkdir(parents=True)
+
+    (repo_root / "robotick" / "robotick-engine").mkdir(parents=True)
+
+    project_yaml = {
+        "runtime": {
+            "engine": {
+                "local_path": "${PROJECT_DIR}/../../robotick/robotick-engine",
+            },
+        }
+    }
+    (project_dir / "pip-e.project.yaml").write_text(yaml.safe_dump(project_yaml))
+    (project_dir / "pip-e-brain.model.yaml").write_text(yaml.safe_dump({"runtime": {}}))
+    (project_dir / "pip-e-face.model.yaml").write_text(yaml.safe_dump({"runtime": {}}))
+
+    brain_spec = load_docker_linux_spec("pip-e", "pip-e-brain", "linux", project_dir)
+    face_spec = load_docker_linux_spec("pip-e", "pip-e-face", "linux", project_dir)
+
+    assert brain_spec is not None
+    assert face_spec is not None
+    assert brain_spec.container_name != face_spec.container_name
+
+
 def test_stop_remote_linux_process_kills_existing_binary(monkeypatch):
     spec = RemoteLinuxSpec(
         host="raspberrypi.local",

--- a/tools/robotick-launcher/tests/launcher/test_remote_linux.py
+++ b/tools/robotick-launcher/tests/launcher/test_remote_linux.py
@@ -446,7 +446,7 @@ def test_build_docker_linux_arm64_execs_inside_keepalive_container(monkeypatch):
             "robotick-launcher-linux-arm64-build-test",
             "bash",
             "-lc",
-            "if [[ -d /opt/robotick/project-target-cache/deps ]]; then mkdir -p /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps && cp -a /opt/robotick/project-target-cache/deps/. /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps/; fi",
+            "if [[ -d /opt/robotick/project-target-cache/deps ]]; then rm -rf /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps && mkdir -p /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps && cp -a /opt/robotick/project-target-cache/deps/. /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps/; fi",
         ],
         [
             "docker",
@@ -608,7 +608,7 @@ def test_build_docker_linux_arm32_execs_inside_keepalive_container(monkeypatch):
             "robotick-launcher-linux-arm32-build-test",
             "bash",
             "-lc",
-            "if [[ -d /opt/robotick/project-target-cache/deps ]]; then mkdir -p /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps && cp -a /opt/robotick/project-target-cache/deps/. /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps/; fi",
+            "if [[ -d /opt/robotick/project-target-cache/deps ]]; then rm -rf /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps && mkdir -p /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps && cp -a /opt/robotick/project-target-cache/deps/. /tmp/repo/.launcher/alf_e/generated/alf_e_face/linux/deps/; fi",
         ],
         [
             "docker",
@@ -884,7 +884,7 @@ def test_build_docker_linux_x64_execs_inside_keepalive_container(monkeypatch):
             "robotick-launcher-linux-x64-build-test",
             "bash",
             "-lc",
-            "if [[ -d /opt/robotick/project-target-cache/deps ]]; then mkdir -p /tmp/repo/.launcher/proj/generated/proj_face/linux/deps && cp -a /opt/robotick/project-target-cache/deps/. /tmp/repo/.launcher/proj/generated/proj_face/linux/deps/; fi",
+            "if [[ -d /opt/robotick/project-target-cache/deps ]]; then rm -rf /tmp/repo/.launcher/proj/generated/proj_face/linux/deps && mkdir -p /tmp/repo/.launcher/proj/generated/proj_face/linux/deps && cp -a /opt/robotick/project-target-cache/deps/. /tmp/repo/.launcher/proj/generated/proj_face/linux/deps/; fi",
         ],
         [
             "docker",


### PR DESCRIPTION
## Summary
Land the small post-merge launcher fixes that knitware now depends on.

## Change List
### Linux Docker targets
- default plain Linux launcher targets to `linux` when `target_platform` is omitted
- make Linux launcher execution containers model-scoped so parallel profile builds do not collide
- refresh cached project-target deps into each model launcher directory before build

### Tests
- add regression coverage for default Linux target resolution
- add regression coverage for model-scoped Linux Docker container names
- update Linux Docker execution tests to match cache refresh behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux platform detection normalization for consistent behavior
  * Enhanced container naming scheme to prevent configuration conflicts
  * Fixed cache directory handling to properly refresh cached contents instead of reusing stale data

* **Tests**
  * Expanded test coverage for Docker container configuration scoping and platform detection validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->