### PR TITLE
Launcher: prepare project Docker/workspace and harden local Linux runtime

### DIFF
--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
@@ -13,6 +13,8 @@ import hashlib
 import os
 import shlex
 import subprocess
+import grp
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
@@ -40,6 +42,7 @@ class DockerLinuxFamilyConfig:
     dockerfile_name: str
     container_name_prefix: str
     supports_runtime: bool
+    use_host_network: bool = False
 
 
 FAMILY_CONFIGS: tuple[DockerLinuxFamilyConfig, ...] = (
@@ -50,6 +53,7 @@ FAMILY_CONFIGS: tuple[DockerLinuxFamilyConfig, ...] = (
         dockerfile_name="robotick-ubuntu24.04-native-linux.Dockerfile",
         container_name_prefix="robotick-launcher-linux-x64-build",
         supports_runtime=True,
+        use_host_network=True,
     ),
     DockerLinuxFamilyConfig(
         family="linux-arm64",
@@ -85,6 +89,7 @@ class DockerLinuxSpec:
     container_working_dir: str
     container_binary_path: str
     supports_runtime: bool
+    use_host_network: bool
 
 
 def load_docker_linux_spec(
@@ -92,13 +97,17 @@ def load_docker_linux_spec(
     model: str,
     target: str,
     base_dir: Path,
+    *,
+    config: Optional[Config] = None,
 ) -> Optional[DockerLinuxSpec]:
     """Build the container execution spec for a Linux launcher target family."""
 
     if target != "linux":
         return None
 
-    config = Config(project, model, target, base_dir, dry_run=False, stub_install=False)
+    config = config or Config(
+        project, model, target, base_dir, dry_run=False, stub_install=False
+    )
     runtime = dict(config.model.get("runtime") or {})
     target_platform = str(runtime.get("target_platform") or target).strip().lower()
     if target_platform != "linux":
@@ -153,6 +162,7 @@ def load_docker_linux_spec(
         container_working_dir=f"{container_root}/{working_dir_rel.as_posix()}",
         container_binary_path=f"{container_root}/{binary_rel.as_posix()}",
         supports_runtime=family_config.supports_runtime,
+        use_host_network=family_config.use_host_network,
     )
 
 
@@ -190,17 +200,44 @@ def deploy_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
 
 def stop_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
     _require_runtime_support(spec, stage="stop")
+    if spec.use_host_network:
+        remove_cmd = ["docker", "rm", "-f", _runtime_container_name(spec)]
+        if dry_run:
+            _print_command(remove_cmd)
+        if not dry_run:
+            subprocess.run(
+                remove_cmd,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        return
     ensure_running_docker_linux_container(spec, dry_run=dry_run)
-    binary_pattern = shlex.quote(spec.container_binary_path)
+    binary_path = shlex.quote(spec.container_binary_path)
+    # Match live processes by /proc/*/exe rather than pkill -f. The old
+    # command-line match could kill the shell running this stop helper because
+    # the binary path itself appeared inside the helper's command string.
     stop_cmd = (
-        f"if pgrep -f -- {binary_pattern} >/dev/null 2>&1; then "
-        f"echo '[Launcher] Stopping existing container instance: {spec.container_binary_path}'; "
-        f"pkill -TERM -f -- {binary_pattern} || true; "
-        "for i in $(seq 1 25); do "
-        f"pgrep -f -- {binary_pattern} >/dev/null 2>&1 || exit 0; "
-        "sleep 0.2; "
+        f"binary_path={binary_path}; "
+        'matching_pids=(); '
+        "for proc_dir in /proc/[0-9]*; do "
+        '  pid=${proc_dir##*/}; '
+        '  exe=$(readlink -f "$proc_dir/exe" 2>/dev/null || true); '
+        '  [[ "$exe" == "$binary_path" ]] || continue; '
+        '  matching_pids+=("$pid"); '
         "done; "
-        f"pkill -KILL -f -- {binary_pattern} || true; "
+        'if ((${#matching_pids[@]})); then '
+        '  echo "[Launcher] Stopping existing container instance: $binary_path"; '
+        '  kill -TERM "${matching_pids[@]}" 2>/dev/null || true; '
+        "  for i in $(seq 1 25); do "
+        "    still_running=0; "
+        '    for pid in "${matching_pids[@]}"; do '
+        '      [[ -e "/proc/$pid/exe" ]] && still_running=1 && break; '
+        "    done; "
+        '    (( still_running == 0 )) && exit 0; '
+        "    sleep 0.2; "
+        "  done; "
+        '  kill -KILL "${matching_pids[@]}" 2>/dev/null || true; '
         "fi; true"
     )
     run_cmd = _docker_exec_command(spec, spec.container_working_dir, stop_cmd)
@@ -209,6 +246,33 @@ def stop_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
 
 def run_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
     _require_runtime_support(spec, stage="run")
+    if spec.use_host_network:
+        ensure_docker_image(spec, dry_run=dry_run)
+        remove_cmd = ["docker", "rm", "-f", _runtime_container_name(spec)]
+        _print_command(remove_cmd)
+        if not dry_run:
+            subprocess.run(
+                remove_cmd,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        binary_dir = Path(spec.container_binary_path).parent.as_posix()
+        engine_lib_dir = f"{binary_dir}/robotick_engine/cpp"
+        run_cmd = _docker_run_command(
+            spec,
+            spec.container_working_dir,
+            (
+                f"export LD_LIBRARY_PATH={shlex.quote(engine_lib_dir)}:{shlex.quote(binary_dir)}:$LD_LIBRARY_PATH && "
+                "if [[ -f ./do_launcher_run.sh ]]; then "
+                "bash ./do_launcher_run.sh; "
+                "else "
+                f"{shlex.quote(spec.container_binary_path)}; "
+                "fi"
+            ),
+        )
+        _run_docker_exec(run_cmd, dry_run=dry_run)
+        return
     ensure_running_docker_linux_container(spec, dry_run=dry_run)
     binary_dir = Path(spec.container_binary_path).parent.as_posix()
     engine_lib_dir = f"{binary_dir}/robotick_engine/cpp"
@@ -229,6 +293,14 @@ def run_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
 
 def ensure_docker_image(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
     if spec.image_name.endswith(":latest"):
+        if _docker_image_exists(spec.image_name) and os.environ.get(
+            "ROBOTICK_LAUNCHER_REFRESH_DOCKER_LATEST", "0"
+        ) != "1":
+            print(
+                "[Launcher] Reusing local Docker image "
+                f"{spec.image_name} (set ROBOTICK_LAUNCHER_REFRESH_DOCKER_LATEST=1 to refresh)"
+            )
+            return
         pull_cmd = ["docker", "pull", spec.image_name]
         _print_command(pull_cmd)
         if not dry_run:
@@ -255,7 +327,27 @@ def ensure_running_docker_linux_container(
     container_image_id = _inspect_docker_value(
         ["docker", "container", "inspect", "-f", "{{.Image}}", spec.container_name]
     )
-    if container_image_id and image_id and container_image_id != image_id:
+    container_network_mode = _inspect_docker_value(
+        [
+            "docker",
+            "container",
+            "inspect",
+            "-f",
+            "{{.HostConfig.NetworkMode}}",
+            spec.container_name,
+        ]
+    )
+    expected_network_mode = "host" if spec.use_host_network else "default"
+    if (
+        container_image_id
+        and image_id
+        and container_image_id != image_id
+        or (
+            container_image_id
+            and container_network_mode
+            and container_network_mode != expected_network_mode
+        )
+    ):
         remove_cmd = ["docker", "rm", "-f", spec.container_name]
         _print_command(remove_cmd)
         if not dry_run:
@@ -274,14 +366,25 @@ def ensure_running_docker_linux_container(
             "--name",
             spec.container_name,
             "--init",
-            "-v",
-            f"{spec.local_repo_root}:{spec.container_workspace_root}",
-            "-w",
-            spec.container_workspace_root,
-            spec.image_name,
-            "sleep",
-            "infinity",
         ]
+        # Native Linux launcher runs should look native from the host's point of
+        # view: Studio probes telemetry from the host, and the model processes
+        # themselves already assume a "local Linux" contract. Host networking
+        # keeps those telemetry ports reachable without adding per-model port
+        # publication plumbing to the generic launcher path.
+        if spec.use_host_network:
+            create_cmd.extend(["--network", "host"])
+        create_cmd.extend(
+            [
+                "-v",
+                f"{spec.local_repo_root}:{spec.container_workspace_root}",
+                "-w",
+                spec.container_workspace_root,
+                spec.image_name,
+                "sleep",
+                "infinity",
+            ]
+        )
         _print_command(create_cmd)
         if not dry_run:
             subprocess.run(
@@ -426,10 +529,161 @@ def _docker_exec_command(
     ]
 
 
+def _docker_run_command(
+    spec: DockerLinuxSpec,
+    working_dir: str,
+    shell_command: str,
+) -> list[str]:
+    runtime_shell_command = _prepare_runtime_shell_command(spec, shell_command)
+    return [
+        "docker",
+        "run",
+        "--name",
+        _runtime_container_name(spec),
+        "--init",
+        "--network",
+        "host",
+        "--user",
+        _resolve_docker_exec_user(),
+        *_runtime_group_add_args(spec),
+        "-e",
+        "HOME=/tmp/robotick-home",
+        "-e",
+        "XDG_RUNTIME_DIR=/tmp/robotick-xdg-runtime",
+        "-v",
+        f"{spec.local_repo_root}:{spec.container_workspace_root}",
+        *_runtime_device_args(spec),
+        "-w",
+        working_dir,
+        spec.image_name,
+        "bash",
+        "-lc",
+        runtime_shell_command,
+    ]
+
+
 def _run_docker_exec(command: list[str], *, dry_run: bool) -> None:
     _print_command(command)
     if not dry_run:
         run_subprocess(command)
+
+
+def _runtime_container_name(spec: DockerLinuxSpec) -> str:
+    return f"{spec.container_name}-run"
+
+
+def _runtime_device_args(spec: DockerLinuxSpec) -> list[str]:
+    """Expose local media/audio devices to native Linux runtime containers.
+
+    The build-stage keepalive containers do not need host devices, but native
+    local runtime models do. Without these mappings the auditory and visual
+    Barr.e workloads can start inside Docker yet fail immediately because ALSA
+    and V4L cannot see the host's microphone/camera nodes.
+    """
+
+    if not spec.use_host_network:
+        return []
+
+    args: list[str] = []
+
+    for device_dir in (Path("/dev/snd"), Path("/dev/dri")):
+        if not device_dir.exists():
+            continue
+        for device in sorted(device_dir.iterdir()):
+            try:
+                mode = device.stat().st_mode
+            except FileNotFoundError:
+                continue
+            if not stat.S_ISCHR(mode) and not stat.S_ISBLK(mode):
+                continue
+            args.extend(["--device", f"{device}:{device}"])
+
+    for pattern in ("/dev/video*", "/dev/media*"):
+        for device in sorted(Path("/dev").glob(pattern.removeprefix("/dev/"))):
+            args.extend(["--device", f"{device}:{device}"])
+
+    return args
+
+
+def _runtime_group_add_args(spec: DockerLinuxSpec) -> list[str]:
+    """Grant runtime containers the host device groups their bind-mounted devices use.
+
+    Docker `--device` mappings preserve the node owner/group, but they do not carry over
+    the host user's ACL entries. For local media/audio models that means a container user
+    matching the caller's uid/gid still cannot open `/dev/snd` or `/dev/video*` unless we
+    add the relevant host groups explicitly.
+    """
+
+    if not spec.use_host_network:
+        return []
+
+    group_names: list[str] = []
+    if Path("/dev/snd").exists():
+        group_names.append("audio")
+    if any(Path("/dev").glob("video*")) or any(Path("/dev").glob("media*")):
+        group_names.append("video")
+    if Path("/dev/dri").exists():
+        group_names.append("render")
+
+    args: list[str] = []
+    for group_name in group_names:
+        gid = _lookup_group_gid(group_name)
+        if gid is not None:
+            args.extend(["--group-add", str(gid)])
+    return args
+
+
+def _lookup_group_gid(group_name: str) -> Optional[int]:
+    try:
+        return grp.getgrnam(group_name).gr_gid
+    except KeyError:
+        return None
+
+
+def _prepare_runtime_shell_command(spec: DockerLinuxSpec, shell_command: str) -> str:
+    """Bootstrap small host-runtime conveniences before the model process starts.
+
+    Native local models are launched inside short-lived `docker run` containers. Some
+    host integrations therefore need a tiny bit of runtime setup inside that container,
+    rather than baked into the shared base image:
+
+    - a writable HOME/XDG runtime dir for libraries that expect them
+    - a minimal ALSA default-device config so audio workloads can use the first local
+      playback/capture card when `/dev/snd` is present
+    """
+
+    if not spec.use_host_network:
+        return shell_command
+
+    setup_lines = [
+        "set -e",
+        'mkdir -p "$HOME" "$XDG_RUNTIME_DIR"',
+        'chmod 700 "$XDG_RUNTIME_DIR" || true',
+    ]
+    if Path("/dev/snd").exists():
+        setup_lines.append(
+            """cat > "$HOME/.asoundrc" <<'EOF'
+pcm.!default {
+  type asym
+  playback.pcm "playback"
+  capture.pcm "capture"
+}
+pcm.playback {
+  type plug
+  slave.pcm "hw:0,0"
+}
+pcm.capture {
+  type plug
+  slave.pcm "hw:0,0"
+}
+ctl.!default {
+  type hw
+  card 0
+}
+EOF"""
+        )
+    setup_lines.append(shell_command)
+    return "\n".join(setup_lines)
 
 
 def _docker_image_exists(image_name: str) -> bool:

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/docker_linux.py
@@ -201,10 +201,19 @@ def deploy_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
 def stop_docker_linux(spec: DockerLinuxSpec, *, dry_run: bool) -> None:
     _require_runtime_support(spec, stage="stop")
     if spec.use_host_network:
-        remove_cmd = ["docker", "rm", "-f", _runtime_container_name(spec)]
+        runtime_container = _runtime_container_name(spec)
+        kill_cmd = ["docker", "kill", runtime_container]
+        remove_cmd = ["docker", "rm", "-f", runtime_container]
         if dry_run:
+            _print_command(kill_cmd)
             _print_command(remove_cmd)
         if not dry_run:
+            subprocess.run(
+                kill_cmd,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
             subprocess.run(
                 remove_cmd,
                 check=False,

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/prepare_project_docker.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/prepare_project_docker.py
@@ -27,6 +27,7 @@ from typing import Iterable, Optional
 
 from rich import print
 
+from robotick.launcher.discover_deps import collect_all_dependencies
 from robotick.launcher.actions.launch.sync_dependencies import sync_model_dependencies
 from robotick.launcher.actions.query.list import list_project_models
 from robotick.launcher.config import Config
@@ -147,6 +148,7 @@ BASE_IMAGE_APT_PACKAGES_BY_FAMILY = {
 }
 ARM64_TARGET_VARIANTS = {"arm64", "aarch64"}
 ARM32_TARGET_VARIANTS = {"arm32", "armhf", "armv7", "armv7hf"}
+MATERIALIZED_DEP_SOURCE_TYPES = frozenset({"git", "git_source_archive", "idf"})
 
 
 @dataclass(frozen=True)
@@ -367,6 +369,80 @@ def _collect_materialized_dependencies(
     return _filter_base_image_apt_packages(family, apt_packages), installed_deps, model_entries
 
 
+def _collect_image_requirement_summary(
+    project: str,
+    base_dir: Path,
+    target: str,
+    family: str,
+    scoped_models: list[str],
+) -> tuple[list[str], list[dict[str, object]], list[dict[str, object]]]:
+    """Summarise image-level requirements without hydrating/copying any deps.
+
+    Warm launches should not pay the cost of fully syncing launcher dependency
+    trees when the selected models only rely on packages already promised by the
+    shared base image. This lightweight scan looks only at declared workload
+    dependencies and decides whether a derived local image is needed at all.
+    """
+
+    apt_packages: set[str] = set()
+    materialized_deps: list[dict[str, object]] = []
+    model_entries: list[dict[str, object]] = []
+
+    for model_name in scoped_models:
+        model_config = Config(
+            project,
+            model_name,
+            target,
+            base_dir,
+            dry_run=False,
+            stub_install=False,
+        )
+        used_workload_types = {
+            workload.get("type")
+            for workload in (model_config.model.get("workloads") or [])
+            if isinstance(workload, dict) and workload.get("type")
+        }
+        deps = collect_all_dependencies(
+            model_config,
+            target,
+            allowed_types=used_workload_types,
+        )
+        model_entries.append(
+            {
+                "model": model_name,
+                "target": target,
+                "target_family": _family_for_model(project, model_name, target, base_dir),
+            }
+        )
+        for dep in deps:
+            source = dep.source
+            if source.type == "apt":
+                package_name = getattr(source, "package", None)
+                if package_name:
+                    apt_packages.add(package_name)
+                continue
+            if source.type not in MATERIALIZED_DEP_SOURCE_TYPES:
+                continue
+            materialized_deps.append(
+                {
+                    "model": model_name,
+                    "name": dep.name,
+                    "source_type": source.type,
+                    "url": getattr(source, "url", None),
+                    "repo": getattr(source, "repo", None),
+                    "asset": getattr(source, "asset", None),
+                    "component": getattr(source, "component", None),
+                    "pin": getattr(source, "pin", None),
+                }
+            )
+
+    return (
+        _filter_base_image_apt_packages(family, apt_packages),
+        materialized_deps,
+        model_entries,
+    )
+
+
 def _render_dockerfile(base_image: str, apt_packages: list[str], include_cache: bool) -> str:
     """Render the small derived Dockerfile for a project-target image.
 
@@ -465,6 +541,55 @@ def prepare_project_docker(
     state_dir = _family_state_dir(project, target, family, base_dir)
     state_dir.mkdir(parents=True, exist_ok=True)
 
+    print(
+        "[Launcher] prepare-project-docker: resolving "
+        f"{family} image for {project}/{target} ({len(scoped_models)} model(s))..."
+    )
+
+    apt_packages, summarized_materialized_deps, model_entries = (
+        _collect_image_requirement_summary(
+            project,
+            base_dir,
+            target,
+            family,
+            scoped_models,
+        )
+    )
+
+    if not apt_packages and not summarized_materialized_deps:
+        resolved_metadata_path = _family_metadata_path(project, target, family, base_dir)
+        resolved_payload = {
+            "family": family,
+            "image_name": base_image,
+            "image_repo": base_image.split(":", 1)[0],
+            "image_tag": base_image.split(":", 1)[-1],
+            "base_image": base_image,
+            "dockerfile_path": "",
+            "context_dir": str(state_dir),
+            "scoped_models": scoped_models,
+            "metadata_path": "",
+            "uses_base_image_directly": True,
+        }
+        if not dry_run:
+            write_text_if_changed(
+                resolved_metadata_path, json.dumps(resolved_payload, indent=2) + "\n"
+            )
+        print(
+            "[Launcher] prepare-project-docker: no project-specific image deps; "
+            f"reusing shared base image {base_image}"
+        )
+        return PreparedProjectDockerInfo(
+            family=family,
+            image_name=base_image,
+            image_repo=base_image.split(":", 1)[0],
+            image_tag=base_image.split(":", 1)[-1],
+            base_image=base_image,
+            metadata_path=resolved_metadata_path,
+            dockerfile_path=state_dir / "Dockerfile",
+            context_dir=state_dir,
+            scoped_models=tuple(scoped_models),
+        )
+
     apt_packages, installed_deps, model_entries = _collect_materialized_dependencies(
         project,
         base_dir,
@@ -533,6 +658,10 @@ def prepare_project_docker(
         write_text_if_changed(
             resolved_metadata_path, json.dumps(resolved_payload, indent=2) + "\n"
         )
+        print(
+            "[Launcher] prepare-project-docker: reusing local project image "
+            f"{image_name}"
+        )
         return PreparedProjectDockerInfo(
             family=family,
             image_name=image_name,
@@ -546,6 +675,10 @@ def prepare_project_docker(
         )
 
     _ensure_base_image(base_image, dry_run=dry_run)
+    print(
+        "[Launcher] prepare-project-docker: building local project image "
+        f"{image_name}"
+    )
     build_cmd = ["docker", "build", "-t", image_name, str(state_dir)]
     _print_command(build_cmd)
     run_subprocess(build_cmd)

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/project_workspace_hydration.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/project_workspace_hydration.py
@@ -191,6 +191,11 @@ def _pip_install(
     if stub_install:
         print("[yellow]⚠️  Stub install requested — skipping pip commands.")
         return
+    if not requirements_files:
+        print(
+            "[dim][Launcher] prepare-project-workspace: no python requirements files; skipping pip install.[/]"
+        )
+        return
     if dry_run:
         for req in requirements_files:
             print(f"[yellow]DRY RUN:[/] would install requirements from {req}")
@@ -542,6 +547,11 @@ def hydrate_project_workspace(
 
     base_dir = base_dir.resolve()
     workspace_root = workspace_root.resolve()
+
+    print(
+        "[Launcher] prepare-project-workspace: hydrating "
+        f"{project}/{target} workspace state under .launcher/..."
+    )
 
     config = Config(
         project,

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/remote_linux.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/remote_linux.py
@@ -44,11 +44,15 @@ def load_remote_linux_spec(
     model: str,
     target: str,
     base_dir: Path,
+    *,
+    config: Optional[Config] = None,
 ) -> Optional[RemoteLinuxSpec]:
     if target != "linux":
         return None
 
-    config = Config(project, model, target, base_dir, dry_run=False, stub_install=False)
+    config = config or Config(
+        project, model, target, base_dir, dry_run=False, stub_install=False
+    )
     runtime = dict(config.model.get("runtime") or {})
     if (runtime.get("target_platform") or "").strip() != "linux":
         return None

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/run_profile.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/run_profile.py
@@ -49,6 +49,36 @@ def _emit_status(status_queue: Optional[Any], **payload):
         pass
 
 
+def _log_stage_start(stage: LaunchStage, detail: str) -> None:
+    """Emit a consistent stage start banner for interactive launcher runs."""
+
+    print(f"[{stage.value}] start — {detail}")
+
+
+def _log_stage_success(stage: LaunchStage, detail: str) -> None:
+    """Emit a consistent stage completion banner for interactive launcher runs."""
+
+    print(f"[green][{stage.value}] done — {detail}[/]")
+
+
+def _log_stage_failure(stage: LaunchStage, detail: str) -> None:
+    """Emit a consistent stage failure banner for interactive launcher runs."""
+
+    print(f"[bold red]❌ [{stage.value}] failed — {detail}[/]")
+
+
+def _log_init_step(detail: str) -> None:
+    """Emit a tagged launcher-init progress line for Studio terminal logs."""
+
+    print(f"[init] {detail}")
+
+
+def _log_init_done(detail: str) -> None:
+    """Emit a tagged launcher-init completion line for Studio terminal logs."""
+
+    print(f"[green][init] done — {detail}[/]")
+
+
 def _signal_process_group(proc: subprocess.Popen, sig: int) -> None:
     if proc.poll() is not None:
         return
@@ -288,6 +318,21 @@ def _profile_selection_is_automatic(project_path: Path, model_spec: str) -> bool
     return model_spec in profiles
 
 
+def _build_project_model_index(project_path: Path) -> dict[str, Path]:
+    """Scan project models once and reuse that map for the whole invocation."""
+
+    model_index: dict[str, Path] = {}
+    for rel_path in list_project_models(str(project_path)):
+        model_path = (project_path.parent / rel_path).resolve()
+        model_id = Path(rel_path).stem.removesuffix(".model")
+        if model_id in model_index:
+            raise RuntimeError(
+                f"Multiple model files found for '{model_id}': {model_index[model_id]} and {model_path}"
+            )
+        model_index[model_id] = model_path
+    return model_index
+
+
 def _resolve_profile_model_target(
     project_name: str,
     base_dir: Path,
@@ -495,34 +540,90 @@ def run_profile(
 
     base_dir = project_path.parent
     project_name = project_path.stem.removesuffix(".project")
-
     try:
-        model_ids = _resolve_profile_model_ids(project_path, model_spec)
+        _log_init_step("loading project configuration...")
+        project_data = yaml.safe_load(project_path.read_text(encoding="utf-8")) or {}
+        _log_init_done("project configuration loaded")
     except Exception as e:
         return {"status": "error", "detail": f"Failed to parse project file: {e}"}
 
     try:
-        auto_launch_policy_applies = _profile_selection_is_automatic(
-            project_path, model_spec
+        _log_init_step("discovering the models in this profile...")
+        model_ids = _resolve_profile_model_ids(project_path, model_spec)
+        _log_init_done(f"discovered {len(model_ids)} model(s) in profile '{profile}'")
+    except Exception as e:
+        return {"status": "error", "detail": f"Failed to parse project file: {e}"}
+
+    try:
+        _log_init_step("indexing project model YAML files...")
+        project_model_index = _build_project_model_index(project_path)
+        _log_init_done(f"indexed {len(project_model_index)} model file(s)")
+    except Exception as e:
+        return {"status": "error", "detail": f"Failed to index project models: {e}"}
+
+    try:
+        _log_init_step("checking whether profile auto-launch policy applies...")
+        auto_launch_policy_applies = _profile_selection_is_automatic(project_path, model_spec)
+        _log_init_done(
+            "profile-level auto-launch rules will be applied"
+            if auto_launch_policy_applies
+            else "explicit model selection will ignore auto-launch=false"
         )
     except Exception as e:
         return {"status": "error", "detail": f"Failed to parse project file: {e}"}
 
     try:
-        model_targets = {
-            model_id: _resolve_profile_model_target(
-                project_name, base_dir, platform, model_id
+        _log_init_step("loading model configuration for target resolution...")
+        model_configs = {
+            model_id: Config(
+                project_name,
+                model_id,
+                None,
+                base_dir,
+                dry_run=False,
+                stub_install=False,
+                project_data=project_data,
+                model_path=project_model_index[model_id],
             )
             for model_id in model_ids
         }
+        _log_init_step("resolving each model's effective target (linux/esp32/etc.)...")
+        if platform == "local":
+            model_targets = {model_id: "linux" for model_id in model_ids}
+        else:
+            model_targets = {}
+            for model_id, model_config in model_configs.items():
+                runtime = dict(model_config.model.get("runtime") or {})
+                model_targets[model_id] = (
+                    str(runtime.get("target_platform") or "linux").strip().lower()
+                    or "linux"
+                )
+        _log_init_done("model targets resolved")
     except Exception as e:
         return {"status": "error", "detail": f"Failed to resolve model targets: {e}"}
 
     try:
-        model_auto_launch = {
-            model_id: _resolve_model_auto_launch(project_name, base_dir, model_id)
-            for model_id in model_ids
-        }
+        _log_init_step("reading per-model launcher auto-launch settings...")
+        model_auto_launch = {}
+        for model_id, model_config in model_configs.items():
+            launcher = model_config.model.get("launcher")
+            if launcher is None:
+                model_auto_launch[model_id] = True
+                continue
+            if not isinstance(launcher, dict):
+                raise ValueError(
+                    f"Model '{model_id}' has invalid 'launcher' section; expected a mapping."
+                )
+            auto_launch = launcher.get("auto_launch")
+            if auto_launch is None:
+                model_auto_launch[model_id] = True
+                continue
+            if not isinstance(auto_launch, bool):
+                raise ValueError(
+                    f"Model '{model_id}' has invalid 'launcher.auto_launch'; expected a boolean."
+                )
+            model_auto_launch[model_id] = auto_launch
+        _log_init_done("launcher auto-launch policy resolved")
     except Exception as e:
         return {
             "status": "error",
@@ -530,15 +631,33 @@ def run_profile(
         }
 
     try:
+        _log_init_step(
+            "loading target-specific config and resolving build/deploy/run plans for each model..."
+        )
+        targeted_model_configs = {
+            model_id: Config(
+                project_name,
+                model_id,
+                model_targets[model_id],
+                base_dir,
+                dry_run=False,
+                stub_install=False,
+                project_data=project_data,
+                model_path=project_model_index[model_id],
+            )
+            for model_id in model_ids
+        }
         model_plans = {
             model_id: resolve_target_plan(
                 project_name,
                 model_id,
                 model_targets[model_id],
                 base_dir,
+                config=targeted_model_configs[model_id],
             )
             for model_id in model_ids
         }
+        _log_init_done("target plans resolved")
     except Exception as e:
         return {"status": "error", "detail": f"Failed to resolve target plans: {e}"}
 
@@ -554,11 +673,17 @@ def run_profile(
         models=model_ids,
     )
 
+    _log_stage_start(
+        LaunchStage.PREPARE_PROJECT_DOCKER,
+        f"resolve container environments for profile '{profile}' "
+        f"across {len(model_ids)} model(s)",
+    )
     _emit_status(
         status_queue,
         event="phase",
-        phase=LaunchStage.BUILD.value,
+        phase=LaunchStage.PREPARE_PROJECT_DOCKER.value,
         status="starting",
+        profile=profile,
         models=model_ids,
     )
 
@@ -575,21 +700,9 @@ def run_profile(
     for target, scoped_models in grouped_models_by_target.items():
         family_groups: dict[str, list[str]] = {}
         for model_id in scoped_models:
-            runtime = dict(
-                Config(
-                    project_name,
-                    model_id,
-                    target,
-                    base_dir,
-                    dry_run=False,
-                    stub_install=False,
-                ).model.get("runtime")
-                or {}
-            )
-            target_platform = (
-                str(runtime.get("target_platform") or target).strip().lower()
-            )
-            target_variant = str(runtime.get("target_variant") or "").strip().lower()
+            plan = model_plans[model_id]
+            target_platform = plan.target_platform
+            target_variant = plan.target_variant
             family = target if target_platform == "esp32" else target_platform
             if target_platform == "linux":
                 if target_variant in {"arm64", "aarch64"}:
@@ -600,33 +713,108 @@ def run_profile(
                     family = "linux-x64"
             family_groups.setdefault(family, []).append(model_id)
 
-        for family_models in family_groups.values():
+        for family_name, family_models in family_groups.items():
             try:
-                prepare_project_docker(
+                _log_stage_start(
+                    LaunchStage.PREPARE_PROJECT_DOCKER,
+                    f"target '{target}' family '{family_name}': "
+                    f"resolve/reuse a project image for {len(family_models)} model(s)",
+                )
+                prepared_info = prepare_project_docker(
                     project=project_name,
                     base_dir=base_dir,
                     target=target,
                     models=family_models,
                 )
+                resolved_image_name = (
+                    prepared_info.image_name
+                    if prepared_info is not None
+                    else "<resolved by prepare-project-docker>"
+                )
+                _log_stage_success(
+                    LaunchStage.PREPARE_PROJECT_DOCKER,
+                    f"target '{target}' family '{family_name}': "
+                    f"using image {resolved_image_name}",
+                )
             except Exception as exc:
                 detail = f"prepare-project-docker failed for target '{target}': {exc}"
-                print(f"[bold red]❌ {detail}[/]")
+                _emit_status(
+                    status_queue,
+                    event="phase",
+                    phase=LaunchStage.PREPARE_PROJECT_DOCKER.value,
+                    status="failed",
+                    target=target,
+                    family=family_name,
+                    detail=detail,
+                )
+                _log_stage_failure(LaunchStage.PREPARE_PROJECT_DOCKER, detail)
                 return {"status": "error", "detail": detail}
+
+        _emit_status(
+            status_queue,
+            event="phase",
+            phase=LaunchStage.PREPARE_PROJECT_WORKSPACE.value,
+            status="starting",
+            target=target,
+            models=scoped_models,
+        )
 
         # Workspace hydration still happens per target because the runtime repo
         # and python state are target-scoped under .launcher/.../deps/...
         try:
-            prepare_project_workspace_stage.prepare_project_workspace(
+            _log_stage_start(
+                LaunchStage.PREPARE_PROJECT_WORKSPACE,
+                f"target '{target}': hydrate persistent .launcher deps state",
+            )
+            workspace_info = prepare_project_workspace_stage.prepare_project_workspace(
                 project=project_name,
                 base_dir=base_dir,
                 workspace_root=base_dir,
                 model=None,
                 target=target,
             )
+            workspace_summary = (
+                f"venv at {workspace_info.venv_path}"
+                if workspace_info is not None
+                else "workspace state hydrated"
+            )
+            _log_stage_success(
+                LaunchStage.PREPARE_PROJECT_WORKSPACE,
+                f"target '{target}': {workspace_summary}",
+            )
+            _emit_status(
+                status_queue,
+                event="phase",
+                phase=LaunchStage.PREPARE_PROJECT_WORKSPACE.value,
+                status="completed",
+                target=target,
+                models=scoped_models,
+            )
         except Exception as exc:
             detail = f"prepare-project-workspace failed for target '{target}': {exc}"
-            print(f"[bold red]❌ {detail}[/]")
+            _emit_status(
+                status_queue,
+                event="phase",
+                phase=LaunchStage.PREPARE_PROJECT_WORKSPACE.value,
+                status="failed",
+                target=target,
+                detail=detail,
+            )
+            _log_stage_failure(LaunchStage.PREPARE_PROJECT_WORKSPACE, detail)
             return {"status": "error", "detail": detail}
+
+    _emit_status(
+        status_queue,
+        event="phase",
+        phase=LaunchStage.PREPARE_PROJECT_DOCKER.value,
+        status="completed",
+        profile=profile,
+        models=model_ids,
+    )
+    _log_stage_success(
+        LaunchStage.PREPARE_PROJECT_DOCKER,
+        f"profile '{profile}': all required project images resolved",
+    )
 
     max_parallel_env = os.getenv("ROBOTICK_LAUNCHER_MAX_PARALLEL_BUILDS", "").strip()
     max_parallel_builds = len(model_ids)
@@ -652,9 +840,16 @@ def run_profile(
     max_parallel_builds = min(max_parallel_builds, len(model_ids))
 
     # --- Build phase (bounded parallelism to avoid CI over-subscription) ---
-    print(
-        "[Launcher] Building "
-        f"{len(model_ids)} models with up to {max_parallel_builds} parallel build(s)..."
+    _log_stage_start(
+        LaunchStage.BUILD,
+        f"build {len(model_ids)} model(s) with up to {max_parallel_builds} parallel worker(s)",
+    )
+    _emit_status(
+        status_queue,
+        event="phase",
+        phase=LaunchStage.BUILD.value,
+        status="starting",
+        models=model_ids,
     )
 
     succeeded: list[str] = []
@@ -760,7 +955,10 @@ def run_profile(
 
     # After build loop:
     if failed:
-        print(f"[bold red]❌ Build failed for: {', '.join(failed)}[/]")
+        _log_stage_failure(
+            LaunchStage.BUILD,
+            f"failed models: {', '.join(failed)}",
+        )
         print("[Launcher] Aborting run phase — at least one build failed.")
         _emit_status(
             status_queue,
@@ -782,7 +980,10 @@ def run_profile(
         }
 
     # If we get here, all builds succeeded:
-    print(f"[Launcher] All builds succeeded. Launching models...")
+    _log_stage_success(
+        LaunchStage.BUILD,
+        f"built {len(succeeded)} model(s) successfully",
+    )
     _emit_status(
         status_queue,
         event="phase",
@@ -798,7 +999,14 @@ def run_profile(
             "skipped_run": True,
             "failed": failed,
         }
-        print("[Launcher] build-profile requested; skipping run phase.")
+        print("[Launcher] build-profile requested; skipping deploy/run stages.")
+        _emit_status(
+            status_queue,
+            event="phase",
+            phase=LaunchStage.DEPLOY.value,
+            status="skipped",
+            launched=[],
+        )
         _emit_status(
             status_queue,
             event="phase",
@@ -806,10 +1014,21 @@ def run_profile(
             status="skipped",
             launched=[],
         )
+        _log_stage_success(
+            LaunchStage.DEPLOY,
+            "skipped because build-profile stops after a successful build",
+        )
+        _log_stage_success(
+            LaunchStage.RUN,
+            "skipped because build-profile stops after a successful build",
+        )
         _emit_status(status_queue, event="result", result=result)
         return result
 
-    print(f"[Launcher] All builds succeeded. Deploying models...")
+    _log_stage_start(
+        LaunchStage.DEPLOY,
+        f"deploy {len(succeeded)} built model(s), deduplicating shared deploy work where possible",
+    )
     _emit_status(
         status_queue,
         event="phase",
@@ -1004,6 +1223,10 @@ def run_profile(
                 )
 
     if deploy_failed:
+        _log_stage_failure(
+            LaunchStage.DEPLOY,
+            f"failed models: {', '.join(deploy_failed)}",
+        )
         print(f"[bold red]❌ Deploy failed for: {', '.join(deploy_failed)}[/]")
         print("[Launcher] Aborting run phase — at least one deploy failed.")
         _emit_status(
@@ -1022,7 +1245,10 @@ def run_profile(
         _emit_status(status_queue, event="result", result=result)
         return result
 
-    print(f"[Launcher] All deploys succeeded. Launching models...")
+    _log_stage_success(
+        LaunchStage.DEPLOY,
+        f"deployed {len(deployed)} model(s) successfully",
+    )
     _emit_status(
         status_queue,
         event="phase",
@@ -1037,16 +1263,21 @@ def run_profile(
     model_health_urls: dict[str, Optional[str]] = {}
     skipped_auto_launch: list[str] = []
 
+    models_to_auto_launch = [
+        model_id
+        for model_id in deployed
+        if (not auto_launch_policy_applies) or model_auto_launch[model_id]
+    ]
+    _log_stage_start(
+        LaunchStage.RUN,
+        f"run {len(models_to_auto_launch)} model(s) and skip models with launcher.auto_launch=false",
+    )
     _emit_status(
         status_queue,
         event="phase",
         phase=LaunchStage.RUN.value,
         status="starting",
-        models=[
-            model_id
-            for model_id in deployed
-            if (not auto_launch_policy_applies) or model_auto_launch[model_id]
-        ],
+        models=models_to_auto_launch,
     )
 
     for model_id in deployed:
@@ -1182,6 +1413,10 @@ def run_profile(
         t.join()
 
     if interrupted:
+        _log_stage_failure(
+            LaunchStage.RUN,
+            "interrupted while waiting for launched model processes",
+        )
         for model_id, proc in run_procs:
             try:
                 rc = proc.wait(timeout=5)
@@ -1230,6 +1465,10 @@ def run_profile(
         status="completed",
         launched=launched_models,
         skipped=skipped_auto_launch,
+    )
+    _log_stage_success(
+        LaunchStage.RUN,
+        f"launched {len(launched_models)} model(s); skipped {len(skipped_auto_launch)} auto-launch-disabled model(s)",
     )
     _emit_status(status_queue, event="result", result=result)
     return result

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/run_profile.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/run_profile.py
@@ -32,6 +32,13 @@ from robotick.launcher.actions.launch.target_plan import resolve_target_plan
 from robotick.launcher.config import Config
 
 
+def _print_plain(message: str) -> None:
+    """Write a plain log line without Rich interpreting bracket tags as markup."""
+
+    sys.stdout.write(f"{message}\n")
+    sys.stdout.flush()
+
+
 def stream_output(proc: subprocess.Popen, tag: str):
     for line in iter(proc.stdout.readline, b""):
         sys.stdout.buffer.write(f"[{tag}] ".encode("utf-8") + line)
@@ -52,31 +59,31 @@ def _emit_status(status_queue: Optional[Any], **payload):
 def _log_stage_start(stage: LaunchStage, detail: str) -> None:
     """Emit a consistent stage start banner for interactive launcher runs."""
 
-    print(f"[{stage.value}] start — {detail}")
+    _print_plain(f"[{stage.value}:/] start — {detail}")
 
 
 def _log_stage_success(stage: LaunchStage, detail: str) -> None:
     """Emit a consistent stage completion banner for interactive launcher runs."""
 
-    print(f"[green][{stage.value}] done — {detail}[/]")
+    _print_plain(f"[{stage.value}:/] done — {detail}")
 
 
 def _log_stage_failure(stage: LaunchStage, detail: str) -> None:
     """Emit a consistent stage failure banner for interactive launcher runs."""
 
-    print(f"[bold red]❌ [{stage.value}] failed — {detail}[/]")
+    _print_plain(f"❌ [{stage.value}:/] failed — {detail}")
 
 
 def _log_init_step(detail: str) -> None:
     """Emit a tagged launcher-init progress line for Studio terminal logs."""
 
-    print(f"[init] {detail}")
+    _print_plain(f"[init:/] {detail}")
 
 
 def _log_init_done(detail: str) -> None:
     """Emit a tagged launcher-init completion line for Studio terminal logs."""
 
-    print(f"[green][init] done — {detail}[/]")
+    _print_plain(f"[init:/] done — {detail}")
 
 
 def _signal_process_group(proc: subprocess.Popen, sig: int) -> None:
@@ -391,6 +398,7 @@ def stop_profile(
     dry_run: bool = False,
     helper_pids: Optional[dict[str, int]] = None,
 ) -> dict[str, object]:
+    _print_plain(f"[stop:/] start — stopping profile '{profile}'")
     if ":" not in profile:
         return {
             "status": "error",
@@ -428,14 +436,23 @@ def stop_profile(
     stopped_models: list[str] = []
     errors: list[str] = []
     results_lock = threading.Lock()
+    stop_started_by_model: dict[str, float] = {}
 
     def _record_success(model_id: str) -> None:
         with results_lock:
             stopped_models.append(model_id)
+            started_at = stop_started_by_model.get(model_id)
+        if started_at is None:
+            _print_plain(f"[stop:{model_id}] done — stopped")
+            return
+        _print_plain(
+            f"[stop:{model_id}] done — stopped in {time.monotonic() - started_at:.3f}s"
+        )
 
     def _record_error(model_id: str, exc: Exception) -> None:
         with results_lock:
             errors.append(f"{model_id}: {exc}")
+        _print_plain(f"❌ [stop:{model_id}] failed — {exc}")
 
     def _stop_one_local_model(
         model_id: str,
@@ -459,16 +476,34 @@ def stop_profile(
 
     local_stop_threads: list[threading.Thread] = []
 
+    def _run_stop_handler_in_thread(
+        model_id: str,
+        stop_handler,
+    ) -> None:
+        try:
+            stop_handler(dry_run)
+            _record_success(model_id)
+        except Exception as exc:
+            _record_error(model_id, exc)
+
     for model_id in reversed(model_ids):
         model_target = model_targets[model_id]
         try:
+            with results_lock:
+                stop_started_by_model[model_id] = time.monotonic()
+            _print_plain(f"[stop:{model_id}] start — stopping model")
             _, _, binary_path = get_launcher_paths(
                 project_name, model_id, model_target, base_dir
             )
             plan = resolve_target_plan(project_name, model_id, model_target, base_dir)
             if plan.run.stop_handler is not None:
-                plan.run.stop_handler(dry_run)
-                _record_success(model_id)
+                thread = threading.Thread(
+                    target=_run_stop_handler_in_thread,
+                    args=(model_id, plan.run.stop_handler),
+                    daemon=True,
+                )
+                thread.start()
+                local_stop_threads.append(thread)
                 continue
 
             if plan.run.strategy == "local":
@@ -490,12 +525,14 @@ def stop_profile(
         thread.join()
 
     if errors:
+        _print_plain(f"❌ [stop:/] failed — {'; '.join(errors)}")
         return {
             "status": "error",
             "detail": "; ".join(errors),
             "stopped": stopped_models,
         }
 
+    _print_plain(f"[stop:/] done — stopped {len(stopped_models)} model(s)")
     return {"status": "stopped", "stopped": stopped_models}
 
 

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/target_plan.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/target_plan.py
@@ -101,14 +101,20 @@ def resolve_target_plan(
     model: str,
     target: str,
     base_dir: Path,
+    *,
+    config: Optional[Config] = None,
 ) -> TargetPlan:
-    config = Config(project, model, target, base_dir, dry_run=False, stub_install=False)
+    config = config or Config(
+        project, model, target, base_dir, dry_run=False, stub_install=False
+    )
     runtime = dict(config.model.get("runtime") or {})
     target_platform = str(runtime.get("target_platform") or target).strip().lower()
     target_variant = str(runtime.get("target_variant") or "").strip().lower()
 
-    container_spec = load_docker_linux_spec(project, model, target, base_dir)
-    remote_spec = load_remote_linux_spec(project, model, target, base_dir)
+    container_spec = load_docker_linux_spec(
+        project, model, target, base_dir, config=config
+    )
+    remote_spec = load_remote_linux_spec(project, model, target, base_dir, config=config)
 
     build = TargetActionPlan(strategy=LOCAL_STRATEGY)
     deploy = TargetActionPlan(strategy=LOCAL_STRATEGY)

--- a/tools/robotick-launcher/src/robotick/launcher/actions/launch/target_plan.py
+++ b/tools/robotick-launcher/src/robotick/launcher/actions/launch/target_plan.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 import shlex
 from pathlib import Path
+import subprocess
+import sys
 from typing import Callable, Optional
 
 from robotick.launcher.actions.launch.docker_linux import (
@@ -65,15 +67,43 @@ class TargetPlan:
     run: TargetActionPlan
 
 
-def _run_generated_stage_script(script_path: Path, dry_run: bool) -> None:
+def _run_generated_stage_script(
+    script_path: Path,
+    dry_run: bool,
+    *,
+    quiet_success: bool = False,
+    quiet_label: Optional[str] = None,
+) -> None:
     cmd = ["bash", str(script_path)]
     quoted = " ".join(shlex.quote(part) for part in cmd)
-    print(f"$ {quoted}")
+    if quiet_success and quiet_label:
+        sys.stdout.write(f"{quiet_label}\n")
+        sys.stdout.flush()
+    else:
+        print(f"$ {quoted}")
     if dry_run:
         return
     if not script_path.exists():
         raise FileNotFoundError(f"Stage script not found: {script_path}")
-    run_subprocess(cmd, cwd=script_path.parent)
+    if not quiet_success:
+        run_subprocess(cmd, cwd=script_path.parent)
+        return
+
+    proc = subprocess.run(
+        cmd,
+        cwd=script_path.parent,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        if proc.stdout:
+            sys.stdout.write(proc.stdout)
+            sys.stdout.flush()
+        if proc.stderr:
+            sys.stderr.write(proc.stderr)
+            sys.stderr.flush()
+        raise subprocess.CalledProcessError(proc.returncode, cmd)
 
 
 def _resolve_custom_stage_script_paths(config: Config) -> dict[LaunchStage, Path]:
@@ -274,7 +304,9 @@ def resolve_target_plan(
             run,
             strategy=LOCAL_STRATEGY,
             stop_handler=lambda dry_run, script=custom_stop_script: _run_generated_stage_script(
-                script, dry_run
+                script,
+                dry_run,
+                quiet_success=True,
             ),
         )
 

--- a/tools/robotick-launcher/src/robotick/launcher/config.py
+++ b/tools/robotick-launcher/src/robotick/launcher/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from rich import print
 import typer
@@ -55,6 +55,9 @@ class Config:
         launcher_path_getter: Optional[
             Callable[[str, str, str, Path], Tuple[Path, Path, Path]]
         ] = None,
+        project_data: Optional[Mapping[str, Any]] = None,
+        model_path: Optional[Path] = None,
+        model_data: Optional[Mapping[str, Any]] = None,
     ):
         from robotick.launcher.utils import get_launcher_paths
 
@@ -70,13 +73,20 @@ class Config:
         self.project_name_safe = project.replace("-", "_")
 
         # Load YAMLs
-        self.project = self._load_yaml(self.project_file)
+        self.project = self._load_yaml(
+            self.project_file, data=project_data, label=str(self.project_file)
+        )
         self.tooling = DotDict({})
         self.runtime = DotDict({})
         self._normalize_project_schema()
         self.model = DotDict({})
         if model:
-            self.model = self._load_yaml(self._find_model_yaml(base_dir, model))
+            resolved_model_path = model_path or self._find_model_yaml(base_dir, model)
+            self.model = self._load_yaml(
+                resolved_model_path,
+                data=model_data,
+                label=str(resolved_model_path),
+            )
 
         # Derived helpers
         self.python_roots: List[PythonRootConfig] = self._parse_python_roots()
@@ -100,7 +110,22 @@ class Config:
             )
         return matches[0]
 
-    def _load_yaml(self, path: Path) -> DotDict:
+    def _load_yaml(
+        self,
+        path: Path,
+        *,
+        data: Optional[Mapping[str, Any]] = None,
+        label: Optional[str] = None,
+    ) -> DotDict:
+        if data is not None:
+            try:
+                return DotDict(dict(data))
+            except Exception as exc:  # pragma: no cover - defensive
+                display = label or str(path)
+                print(f"[red]❌ Failed to parse YAML data:[/] {display}")
+                print(f"[red]Reason:[/] {exc}")
+                raise typer.Exit(1)
+
         if not path.exists():
             print(f"[red]❌ Missing YAML file:[/] {path}")
             raise typer.Exit(1)

--- a/tools/robotick-launcher/src/robotick/launcher/listen/routes_launch.py
+++ b/tools/robotick-launcher/src/robotick/launcher/listen/routes_launch.py
@@ -84,6 +84,46 @@ class _QueueStream:
             self._buffer = ""
 
 
+class _BroadcastStream:
+    """Mirror listener-thread output to websocket log subscribers line by line."""
+
+    def __init__(self, passthrough):
+        self.passthrough = passthrough
+        self._buffer = ""
+        self._lock = threading.Lock()
+        self.buffer = self
+        self.encoding = getattr(passthrough, "encoding", "utf-8")
+
+    def write(self, data: str):
+        if not data:
+            return 0
+        with self._lock:
+            if isinstance(data, bytes):
+                text = data.decode(self.encoding or "utf-8", errors="replace")
+            else:
+                text = str(data)
+            self.passthrough.write(text)
+            self.passthrough.flush()
+            self._buffer += text
+            loop = log_loop
+            while "\n" in self._buffer:
+                line, self._buffer = self._buffer.split("\n", 1)
+                if loop is not None:
+                    _broadcast_log(line, loop)
+        return len(text)
+
+    def flush(self):
+        self.passthrough.flush()
+
+    def close(self):
+        with self._lock:
+            if self._buffer:
+                loop = log_loop
+                if loop is not None:
+                    _broadcast_log(self._buffer, loop)
+                self._buffer = ""
+
+
 def _set_initial_status(profile: str):
     with status_lock:
         current_status.clear()
@@ -261,8 +301,6 @@ def _status_consumer(loop: asyncio.AbstractEventLoop):
 
     if current_status.get("status") not in ("error", "completed", "stopping"):
         _set_stopped_status()
-    _close_log_subscribers()
-
 
 def _tracked_helper_pids() -> dict[str, int]:
     with status_lock:
@@ -404,28 +442,37 @@ def _stop_launcher_worker() -> None:
         process_handle = None
         status_queue = None
         status_thread = None
-        current_profile = None
-        current_project_path = None
-        current_run_started_at = None
-        log_loop = None
 
     if profile and project_path:
-        try:
-            run_profile_module.stop_profile(
-                project=project_path.name.removesuffix(".project.yaml"),
-                profile=profile,
-                base_dir=project_path.parent,
-                helper_pids=helper_pids,
-            )
-        except Exception as exc:
-            print(f"[Launcher] Best-effort profile stop failed: {exc}")
+        stdout = _BroadcastStream(sys.__stdout__)
+        stderr = _BroadcastStream(sys.__stderr__)
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            try:
+                stop_started_at = time.monotonic()
+                run_profile_module.stop_profile(
+                    project=project_path.name.removesuffix(".project.yaml"),
+                    profile=profile,
+                    base_dir=project_path.parent,
+                    helper_pids=helper_pids,
+                )
+                stop_elapsed = time.monotonic() - stop_started_at
+                print(f"[stop:/] model stop completed in {stop_elapsed:.3f}s")
+            except Exception as exc:
+                print(f"[Launcher] Best-effort profile stop failed: {exc}")
+            finally:
+                stdout.close()
+                stderr.close()
 
     if proc and proc.is_alive():
+        reap_started_at = time.monotonic()
         proc.terminate()
-        proc.join(timeout=3)
+        proc.join(timeout=0.25)
         if proc.is_alive():
             proc.kill()
-            proc.join(timeout=1)
+            proc.join(timeout=0.25)
+        print(
+            f"[stop:/] launcher worker cleanup completed in {time.monotonic() - reap_started_at:.3f}s"
+        )
 
     if queue:
         try:
@@ -439,9 +486,12 @@ def _stop_launcher_worker() -> None:
         thread.join(timeout=1)
 
     _set_stopped_status()
-    _close_log_subscribers()
 
     with lifecycle_lock:
+        current_profile = None
+        current_project_path = None
+        current_run_started_at = None
+        log_loop = None
         stop_thread = None
 
 

--- a/tools/robotick-launcher/tests/launcher/test_prepare_project_docker.py
+++ b/tools/robotick-launcher/tests/launcher/test_prepare_project_docker.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import yaml
+
+from robotick.launcher.actions.launch import prepare_project_docker as prepare_project_docker_module
 from robotick.launcher.actions.launch.prepare_project_docker import (
     _filter_base_image_apt_packages,
+    prepare_project_docker,
     project_cache_materialize_shell,
 )
 
@@ -30,3 +35,38 @@ def test_project_cache_materialize_shell_quotes_paths():
 
     assert "/opt/robotick/project-target-cache/deps" in command
     assert "'/tmp/workspace with spaces/generated/linux/deps'" in command
+
+
+def test_prepare_project_docker_reuses_shared_base_when_no_project_specific_image_deps(
+    tmp_path, monkeypatch
+):
+    base_dir = tmp_path / "robots" / "barr-e"
+    base_dir.mkdir(parents=True)
+    (base_dir / "barr-e.project.yaml").write_text(
+        yaml.safe_dump({"runtime": {"engine": {"local_path": "../engine"}}})
+    )
+    (base_dir / "barr-e-brain.model.yaml").write_text(
+        yaml.safe_dump({"runtime": {"target_platform": "linux", "target_variant": "x86_64"}})
+    )
+
+    monkeypatch.setattr(
+        prepare_project_docker_module,
+        "_collect_image_requirement_summary",
+        lambda *args, **kwargs: ([], [], [{"model": "barr-e-brain"}]),
+    )
+
+    info = prepare_project_docker(
+        "barr-e",
+        base_dir,
+        target="linux",
+        models=["barr-e-brain"],
+    )
+
+    assert info is not None
+    assert (
+        info.image_name
+        == "ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest"
+    )
+    payload = json.loads(info.metadata_path.read_text(encoding="utf-8"))
+    assert payload["uses_base_image_directly"] is True
+    assert payload["image_name"] == info.image_name

--- a/tools/robotick-launcher/tests/launcher/test_remote_linux.py
+++ b/tools/robotick-launcher/tests/launcher/test_remote_linux.py
@@ -1113,7 +1113,10 @@ def test_stop_docker_linux_x64_kills_existing_binary_inside_container(monkeypatc
     stop_docker_linux_x64(spec, dry_run=False)
 
     assert ensure_calls == []
-    assert rm_calls == [["docker", "rm", "-f", "robotick-launcher-linux-x64-build-test-run"]]
+    assert rm_calls == [
+        ["docker", "kill", "robotick-launcher-linux-x64-build-test-run"],
+        ["docker", "rm", "-f", "robotick-launcher-linux-x64-build-test-run"],
+    ]
 
 
 def test_run_docker_linux_x64_execs_run_script_inside_keepalive_container(monkeypatch):
@@ -1358,17 +1361,29 @@ def test_resolve_target_plan_ros2_handlers_execute_generated_scripts(
     run_script.write_text("#!/bin/bash\nset -e\n", encoding="utf-8")
     stop_script.write_text("#!/bin/bash\nset -e\n", encoding="utf-8")
 
-    calls: list[tuple[list[str], Path | None]] = []
+    run_subprocess_calls: list[tuple[list[str], Path | None]] = []
+    subprocess_run_calls: list[tuple[list[str], Path | None]] = []
 
     def _fake_run_subprocess(cmd, cwd=None, **kwargs):
-        calls.append((cmd, cwd))
+        run_subprocess_calls.append((cmd, cwd))
 
         class _Proc:
             returncode = 0
 
         return _Proc()
 
+    def _fake_subprocess_run(cmd, cwd=None, text=None, capture_output=None, check=None):
+        subprocess_run_calls.append((cmd, cwd))
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Completed()
+
     monkeypatch.setattr(target_plan_module, "run_subprocess", _fake_run_subprocess)
+    monkeypatch.setattr(target_plan_module.subprocess, "run", _fake_subprocess_run)
 
     plan = resolve_target_plan("proj", "proj-sim", "linux", project_dir)
     assert plan.run.run_handler is not None
@@ -1376,7 +1391,9 @@ def test_resolve_target_plan_ros2_handlers_execute_generated_scripts(
     plan.run.stop_handler(False)
     plan.run.run_handler(False)
 
-    assert calls == [
+    assert subprocess_run_calls == [
         (["bash", str(stop_script)], stop_script.parent),
+    ]
+    assert run_subprocess_calls == [
         (["bash", str(run_script)], run_script.parent),
     ]

--- a/tools/robotick-launcher/tests/launcher/test_remote_linux.py
+++ b/tools/robotick-launcher/tests/launcher/test_remote_linux.py
@@ -61,7 +61,10 @@ def _docker_linux_spec(
     workspace_root: str = "/tmp/repo",
     working_dir: str = "/tmp/repo/robots/proj",
     supports_runtime: bool = False,
+    use_host_network: bool | None = None,
 ) -> DockerLinuxSpec:
+    if use_host_network is None:
+        use_host_network = family == "linux-x64"
     return DockerLinuxSpec(
         family=family,
         image_name=image_name,
@@ -75,6 +78,7 @@ def _docker_linux_spec(
         container_working_dir=working_dir,
         container_binary_path=binary_path,
         supports_runtime=supports_runtime,
+        use_host_network=use_host_network,
     )
 
 
@@ -234,6 +238,86 @@ def test_load_docker_linux_spec_uses_model_scoped_container_name(tmp_path):
     assert brain_spec is not None
     assert face_spec is not None
     assert brain_spec.container_name != face_spec.container_name
+
+
+def test_stop_docker_linux_matches_exact_binary_exe_path(monkeypatch):
+    spec = _docker_linux_spec(
+        family="linux-x64",
+        image_name="ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
+        dockerfile="/tmp/Dockerfile",
+        container_name="robotick-launcher-linux-x64-build-123",
+        launcher_dir="/tmp/repo/.launcher/proj/generated/proj_face/linux",
+        binary_path="/tmp/repo/.launcher/proj/generated/proj_face/linux/build/proj-face",
+        supports_runtime=True,
+        use_host_network=False,
+    )
+
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(
+        docker_linux_module,
+        "ensure_running_docker_linux_container",
+        lambda spec, dry_run: None,
+    )
+    monkeypatch.setattr(
+        docker_linux_module,
+        "_run_docker_exec",
+        lambda command, dry_run: recorded.append(command),
+    )
+
+    stop_docker_linux(spec, dry_run=False)
+
+    assert len(recorded) == 1
+    shell_command = recorded[0][-1]
+    assert 'readlink -f "$proc_dir/exe"' in shell_command
+    assert 'kill -TERM "${matching_pids[@]}"' in shell_command
+    assert "pkill -f" not in shell_command
+
+
+def test_ensure_docker_linux_image_reuses_local_latest_by_default(monkeypatch):
+    spec = _docker_linux_spec(
+        family="linux-x64",
+        image_name="ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
+        dockerfile="/tmp/Dockerfile",
+        container_name="robotick-launcher-linux-x64-build-123",
+        launcher_dir="/tmp/repo/.launcher/proj/generated/proj_face/linux",
+        binary_path="/tmp/repo/.launcher/proj/generated/proj_face/linux/build/proj-face",
+        supports_runtime=True,
+    )
+
+    commands: list[list[str]] = []
+    monkeypatch.setattr(docker_linux_module, "_docker_image_exists", lambda image: True)
+    monkeypatch.setattr(
+        docker_linux_module,
+        "run_subprocess",
+        lambda command: commands.append(command),
+    )
+
+    ensure_docker_linux_image(spec, dry_run=False)
+
+    assert commands == []
+
+
+def test_ensure_docker_linux_x64_image_refreshes_latest_when_requested(monkeypatch):
+    spec = _docker_linux_spec(
+        family="linux-x64",
+        image_name="ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
+        dockerfile="/tmp/robotick-ubuntu24.04-native-linux.Dockerfile",
+        container_name="robotick-launcher-linux-x64-build-test",
+        launcher_dir="/tmp/repo/.launcher/proj/generated/proj_face/linux",
+        binary_path="/tmp/repo/.launcher/proj/generated/proj_face/linux/build/proj-face",
+        supports_runtime=True,
+    )
+    pull_calls: list[list[str]] = []
+
+    monkeypatch.setenv("ROBOTICK_LAUNCHER_REFRESH_DOCKER_LATEST", "1")
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux.run_subprocess",
+        lambda cmd: pull_calls.append(cmd),
+    )
+
+    ensure_docker_linux_x64_image(spec, dry_run=False)
+
+    assert pull_calls == [["docker", "pull", spec.image_name]]
 
 
 def test_stop_remote_linux_process_kills_existing_binary(monkeypatch):
@@ -502,7 +586,7 @@ def test_docker_exec_command_falls_back_when_platform_has_no_getuid(monkeypatch)
     assert command[10:] == ["-lc", "bash ./do_launcher_build.sh"]
 
 
-def test_ensure_docker_linux_arm64_image_refreshes_latest(monkeypatch):
+def test_ensure_docker_linux_arm64_image_reuses_local_latest_by_default(monkeypatch):
     spec = _docker_linux_spec(
         family="linux-arm64",
         image_name="ghcr.io/robotick-labs/robotick-debian12-cross-linux-arm64:latest",
@@ -520,7 +604,7 @@ def test_ensure_docker_linux_arm64_image_refreshes_latest(monkeypatch):
 
     ensure_docker_linux_arm64_image(spec, dry_run=False)
 
-    assert pull_calls == [["docker", "pull", spec.image_name]]
+    assert pull_calls == []
 
 
 def test_load_docker_linux_arm32_spec_points_at_shared_engine_dockerfile(tmp_path):
@@ -627,7 +711,7 @@ def test_build_docker_linux_arm32_execs_inside_keepalive_container(monkeypatch):
     ]
 
 
-def test_ensure_docker_linux_arm32_image_refreshes_latest(monkeypatch):
+def test_ensure_docker_linux_arm32_image_reuses_local_latest_by_default(monkeypatch):
     spec = _docker_linux_spec(
         family="linux-arm32",
         image_name="ghcr.io/robotick-labs/robotick-debian12-cross-linux-arm32:latest",
@@ -645,7 +729,7 @@ def test_ensure_docker_linux_arm32_image_refreshes_latest(monkeypatch):
 
     ensure_docker_linux_arm32_image(spec, dry_run=False)
 
-    assert pull_calls == [["docker", "pull", spec.image_name]]
+    assert pull_calls == []
 
 
 def test_resolve_target_plan_prefers_docker_build_and_remote_run_for_pi5_models(
@@ -903,7 +987,7 @@ def test_build_docker_linux_x64_execs_inside_keepalive_container(monkeypatch):
     ]
 
 
-def test_ensure_docker_linux_x64_image_refreshes_latest(monkeypatch):
+def test_ensure_docker_linux_x64_image_reuses_local_latest_by_default(monkeypatch):
     spec = _docker_linux_spec(
         family="linux-x64",
         image_name="ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
@@ -922,7 +1006,7 @@ def test_ensure_docker_linux_x64_image_refreshes_latest(monkeypatch):
 
     ensure_docker_linux_x64_image(spec, dry_run=False)
 
-    assert pull_calls == [["docker", "pull", spec.image_name]]
+    assert pull_calls == []
 
 
 def test_ensure_running_docker_linux_x64_container_dry_run_tolerates_missing_docker(
@@ -1015,44 +1099,21 @@ def test_stop_docker_linux_x64_kills_existing_binary_inside_container(monkeypatc
         supports_runtime=True,
     )
     ensure_calls: list[tuple[DockerLinuxX64Spec, bool]] = []
-    run_calls: list[list[str]] = []
+    rm_calls: list[list[str]] = []
 
     monkeypatch.setattr(
         "robotick.launcher.actions.launch.docker_linux.ensure_running_docker_linux_container",
         lambda actual_spec, dry_run: ensure_calls.append((actual_spec, dry_run)),
     )
     monkeypatch.setattr(
-        "robotick.launcher.actions.launch.docker_linux.os.getuid",
-        lambda: 1234,
-    )
-    monkeypatch.setattr(
-        "robotick.launcher.actions.launch.docker_linux.os.getgid",
-        lambda: 5678,
-    )
-    monkeypatch.setattr(
-        "robotick.launcher.actions.launch.docker_linux.run_subprocess",
-        lambda cmd: run_calls.append(cmd),
+        "robotick.launcher.actions.launch.docker_linux.subprocess.run",
+        lambda cmd, check=False, stdout=None, stderr=None: rm_calls.append(cmd),
     )
 
     stop_docker_linux_x64(spec, dry_run=False)
 
-    assert ensure_calls == [(spec, False)]
-    assert run_calls[0][:10] == [
-        "docker",
-        "exec",
-        "--user",
-        "1234:5678",
-        "-e",
-        "HOME=/tmp/robotick-home",
-        "-w",
-        "/tmp/repo/robots/proj",
-        "robotick-launcher-linux-x64-build-test",
-        "bash",
-    ]
-    assert (
-        "pkill -TERM -f -- /tmp/repo/.launcher/proj/generated/proj_face/linux/build/proj-face"
-        in run_calls[0][11]
-    )
+    assert ensure_calls == []
+    assert rm_calls == [["docker", "rm", "-f", "robotick-launcher-linux-x64-build-test-run"]]
 
 
 def test_run_docker_linux_x64_execs_run_script_inside_keepalive_container(monkeypatch):
@@ -1069,10 +1130,6 @@ def test_run_docker_linux_x64_execs_run_script_inside_keepalive_container(monkey
     run_calls: list[list[str]] = []
 
     monkeypatch.setattr(
-        "robotick.launcher.actions.launch.docker_linux.ensure_running_docker_linux_container",
-        lambda actual_spec, dry_run: ensure_calls.append((actual_spec, dry_run)),
-    )
-    monkeypatch.setattr(
         "robotick.launcher.actions.launch.docker_linux.os.getuid",
         lambda: 1234,
     )
@@ -1084,27 +1141,134 @@ def test_run_docker_linux_x64_execs_run_script_inside_keepalive_container(monkey
         "robotick.launcher.actions.launch.docker_linux.run_subprocess",
         lambda cmd: run_calls.append(cmd),
     )
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux._docker_image_exists",
+        lambda image: True,
+    )
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux._runtime_device_args",
+        lambda spec: [],
+    )
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux._runtime_group_add_args",
+        lambda spec: ["--group-add", "29", "--group-add", "44"],
+    )
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux.subprocess.run",
+        lambda cmd, check=False, stdout=None, stderr=None: ensure_calls.append((spec, False)),
+    )
 
     run_docker_linux_x64(spec, dry_run=False)
 
     assert ensure_calls == [(spec, False)]
-    assert run_calls[0][:10] == [
+    assert run_calls[0][:18] == [
         "docker",
-        "exec",
+        "run",
+        "--name",
+        "robotick-launcher-linux-x64-build-test-run",
+        "--init",
+        "--network",
+        "host",
         "--user",
         "1234:5678",
+        "--group-add",
+        "29",
+        "--group-add",
+        "44",
         "-e",
         "HOME=/tmp/robotick-home",
+        "-e",
+        "XDG_RUNTIME_DIR=/tmp/robotick-xdg-runtime",
+        "-v",
+    ]
+    assert run_calls[0][18] == "/tmp/repo:/tmp/repo"
+    assert run_calls[0][19:24] == [
         "-w",
         "/tmp/repo/robots/proj",
-        "robotick-launcher-linux-x64-build-test",
+        "ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
         "bash",
+        "-lc",
     ]
+    assert "mkdir -p \"$HOME\" \"$XDG_RUNTIME_DIR\"" in run_calls[0][24]
+    assert "chmod 700 \"$XDG_RUNTIME_DIR\" || true" in run_calls[0][24]
     assert (
         "export LD_LIBRARY_PATH=/tmp/repo/.launcher/proj/generated/proj_face/linux/build/robotick_engine/cpp:/tmp/repo/.launcher/proj/generated/proj_face/linux/build:$LD_LIBRARY_PATH"
-        in run_calls[0][11]
+        in run_calls[0][24]
     )
-    assert "bash ./do_launcher_run.sh" in run_calls[0][11]
+    assert "bash ./do_launcher_run.sh" in run_calls[0][24]
+
+
+def test_prepare_runtime_shell_command_adds_alsa_bootstrap_for_local_runtime(monkeypatch):
+    spec = _docker_linux_spec(
+        family="linux-x64",
+        image_name="ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
+        dockerfile="/tmp/robotick-ubuntu24.04-native-linux.Dockerfile",
+        container_name="robotick-launcher-linux-x64-build-test",
+        launcher_dir="/tmp/repo/.launcher/proj/generated/proj_face/linux",
+        binary_path="/tmp/repo/.launcher/proj/generated/proj_face/linux/build/proj-face",
+        supports_runtime=True,
+    )
+
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux.Path.exists",
+        lambda self: str(self) == "/dev/snd",
+    )
+
+    command = docker_linux_module._prepare_runtime_shell_command(
+        spec, "bash ./do_launcher_run.sh"
+    )
+
+    assert "set -e" in command
+    assert 'mkdir -p "$HOME" "$XDG_RUNTIME_DIR"' in command
+    assert 'cat > "$HOME/.asoundrc"' in command
+    assert 'slave.pcm "hw:0,0"' in command
+    assert "bash ./do_launcher_run.sh" in command
+
+
+def test_runtime_group_add_args_include_audio_video_render_when_present(monkeypatch):
+    spec = _docker_linux_spec(
+        family="linux-x64",
+        image_name="ghcr.io/robotick-labs/robotick-ubuntu24.04-native-linux:latest",
+        dockerfile="/tmp/robotick-ubuntu24.04-native-linux.Dockerfile",
+        container_name="robotick-launcher-linux-x64-build-test",
+        launcher_dir="/tmp/repo/.launcher/proj/generated/proj_face/linux",
+        binary_path="/tmp/repo/.launcher/proj/generated/proj_face/linux/build/proj-face",
+        supports_runtime=True,
+    )
+
+    monkeypatch.setattr(
+        docker_linux_module,
+        "_lookup_group_gid",
+        lambda name: {"audio": 29, "video": 44, "render": 992}.get(name),
+    )
+
+    def fake_exists(self):
+        return str(self) in {"/dev/snd", "/dev/dri"}
+
+    def fake_glob(self, pattern):
+        if str(self) != "/dev":
+            return []
+        if pattern == "video*":
+            return [Path("/dev/video0")]
+        if pattern == "media*":
+            return [Path("/dev/media0")]
+        return []
+
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux.Path.exists", fake_exists
+    )
+    monkeypatch.setattr(
+        "robotick.launcher.actions.launch.docker_linux.Path.glob", fake_glob
+    )
+
+    assert docker_linux_module._runtime_group_add_args(spec) == [
+        "--group-add",
+        "29",
+        "--group-add",
+        "44",
+        "--group-add",
+        "992",
+    ]
 
 
 def test_resolve_target_plan_uses_container_strategies_for_plain_linux_models(tmp_path):

--- a/tools/robotick-launcher/tests/launcher/test_run_profile.py
+++ b/tools/robotick-launcher/tests/launcher/test_run_profile.py
@@ -596,7 +596,7 @@ def test_run_profile_dedupes_shared_remote_deploy(monkeypatch, tmp_path):
         "$HOME/dev/robotick/robots/alf-e",
     )
 
-    def _fake_resolve_target_plan(project, model, target, base_dir):
+    def _fake_resolve_target_plan(project, model, target, base_dir, config=None):
         return TargetPlan(
             project=project,
             model=model,


### PR DESCRIPTION
## Summary
Refine launcher staging around prepared project Docker/workspace state, unify Linux Docker execution, and harden the local Barr.e runtime path.

## Change List
### Launcher stages
- add and document canonical launcher stages
- split project-image preparation from project-workspace hydration
- rename the old workspace hydration path to clearer project-workspace language

### Linux Docker flow
- unify Linux Docker execution into one generic launcher path
- make native local Linux runs use Docker by default
- improve stage/init logging for Studio and launcher terminal output

### Local runtime robustness
- make local Linux runtime containers behave more like native runs
- fix Barr.e health visibility and stop behavior for Docker-backed local models
- tighten listener stop/reporting behavior and reduce shutdown noise

### Tests and docs
- expand launcher coverage for the new stage model and Linux Docker flow
- document stage ordering and the Python-orchestrates / shell-executes pattern
